### PR TITLE
Add radio buttons for sorting challenges

### DIFF
--- a/pages/api/maps.ts
+++ b/pages/api/maps.ts
@@ -13,13 +13,14 @@ export default async function handler(
 
     const page = parseInt(req.query.page as string) || 1; // Default to page 1 if not provided
     const limit = parseInt(req.query.limit as string) || 12; // Default to 10 documents per page if not provided
+    const sortByLikes = !!(parseInt(req.query.sortByLikes as string) || 0); // Sort by no of challenges by default
     const skip = (page - 1) * limit;
 
     // Fetch all documents from the 'maps' collection sorted by number of challenges
     const maps: WithId<Document>[] = await db
       .collection('maps')
       .find({})
-      .sort({ challenges: -1 })
+      .sort(sortByLikes ? { likes: -1 } : { challenges: -1 })
       .skip(skip)
       .limit(limit)
       .toArray();

--- a/pages/api/maps/search.ts
+++ b/pages/api/maps/search.ts
@@ -12,6 +12,8 @@ export default async function handler(
     const db = client.db('Cluster0'); // Replace with your actual database name
 
     const query = req.query.query as string;
+    const sortByLikes = !!(parseInt(req.query.sortByLikes as string) || 0); // Sort by no of challenges by default
+
     if (!query) {
       return res.status(400).json({ message: 'Query parameter is required' });
     }
@@ -20,7 +22,7 @@ export default async function handler(
     const maps: WithId<Document>[] = await db
       .collection('maps')
       .find({ name: { $regex: query, $options: 'i' } }) // Case-insensitive search
-      .sort({ challenges: -1 })
+      .sort(sortByLikes ? { likes: -1 } : { challenges: -1 })
       .toArray();
 
     // Transform the documents into Map[] type

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,6 +33,7 @@ const Home: React.FC = () => {
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [showUploadPopup, setShowUploadPopup] = useState<boolean>(false);
   const [page, setPage] = useState<number>(1);
+  const [sortByLikes, setSortByLikes] = useState<number>(0);
   const [showLoadMore, setShowLoadMore] = useState(true);
   const [loading, setLoading] = useState(true);
 
@@ -48,10 +49,10 @@ const Home: React.FC = () => {
     setShowPlayPopup(true);
   };
 
-  const fetchMaps = async (page: number) => {
+  const fetchMaps = async (page: number, sortByLikes: number = 0) => {
     setLoading(true);
     try {
-      const response = await fetch(`/api/maps?page=${page}`);
+      const response = await fetch(`/api/maps?page=${page}?sortByLikes=${sortByLikes}`);
       const data: Map[] = await response.json();
 
       // Format the fetched data
@@ -79,12 +80,8 @@ const Home: React.FC = () => {
   };
 
   useEffect(() => {
-
-
-    fetchMaps(page);
-
-
-  }, [page]);
+    fetchMaps(page, sortByLikes);
+  }, [page, sortByLikes]);
 
   const handleSearch = async () => {
     if (!searchTerm) {
@@ -92,13 +89,13 @@ const Home: React.FC = () => {
       // Fetch all maps when search term is empty
       setShowLoadMore(true);
       setPage(1);
-      fetchMaps(1);
+      fetchMaps(1, sortByLikes);
       return;
     }
     setLoading(true);
 
     try {
-      const response = await fetch(`/api/maps/search?query=${searchTerm}`);
+      const response = await fetch(`/api/maps/search?query=${searchTerm}?sortByLikes=${sortByLikes}`);
       const data: Map[] = await response.json();
       setMaps(data);
       setShowLoadMore(false);
@@ -117,6 +114,10 @@ const Home: React.FC = () => {
   // const filteredMaps = maps.filter((map) =>
   //   map.name.toLowerCase().includes(searchTerm.toLowerCase())
   // );
+
+  const handleSortChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSortByLikes(event.target.value === "byLikes" ? 1 : 0);
+  };
 
   return (
     <>
@@ -181,7 +182,26 @@ const Home: React.FC = () => {
         </button>
 
       </div>
-
+      <div className={styles.radioGroup}>
+        <label className={styles.radioLabel}>
+          <input
+            type="radio"
+            value="byChallenges"
+            checked={sortByLikes === 0}
+            onChange={handleSortChange}
+          />
+          <span>Sort by challenges</span>
+        </label>
+        <label className={styles.radioLabel}>
+          <input
+            type="radio"
+            value="byLikes"
+            checked={sortByLikes === 1}
+            onChange={handleSortChange}
+          />
+          <span>Sort by likes</span>
+        </label>
+      </div>
 
 
       <div className={styles.mapList}>

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -212,3 +212,24 @@
     right: 20px;
     top: 20px;
 }
+
+.radioGroup {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.radioLabel {
+  display: flex;
+  align-items: flex-start;
+}
+
+.radioLabel input {
+  flex-shrink: 0;
+  align-items: flex-start;
+
+}
+.radioText {
+  display: block;
+  margin-left: 8px;
+}


### PR DESCRIPTION
This commit adds radio buttons to select the sorting method (by likes or by the number of challenges). I wasn’t able to access the database to fully test the sorting functionality, but the implementation is straightforward and should work as expected.